### PR TITLE
Go private ping msg Change ping message format to JSON

### DIFF
--- a/V5_demo/wss_demo/go/ws_private_demo.go
+++ b/V5_demo/wss_demo/go/ws_private_demo.go
@@ -29,7 +29,7 @@ func connect() {
 	ticker := time.NewTicker(20 * time.Second)
 	go func() {
 		for range ticker.C {
-			err := c.WriteMessage(websocket.TextMessage, []byte("ping"))
+			err := c.WriteMessage(websocket.TextMessage, []byte(`{"op": "ping"}`))
 			if err != nil {
 				log.Println("Failed to send ping:", err)
 			}


### PR DESCRIPTION
Prior sending ping was incorrect, an error would be received. The correct format should be {"op": "ping"}.